### PR TITLE
Update the current color settings in styles.css to use Github's color variables

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
 .selected {
-  background-color: #2D333B;
-  border-left: 4px solid #0366d6;
+  background-color: var(--bgColor-muted, transparent) !important;
+  border-left: 4px solid var(--borderColor-accent-emphasis, #0969da);
 }


### PR DESCRIPTION
I update the current color settings in styles.css to use Github's color variables. If Github changes these variables in the future, the following settings will serve as fallbacks:
- background-color: transparent
- border-color: #0969da


**日本語**
色指定をgithubの定義したものを使用するに変更。
今後githubが色定義を変更した場合にも、background-color: transparent, border-color: #0969daにはなるように設定。


**After Video**
light mode

https://github.com/kyu08/github-issue-pr-navigator/assets/105255294/f9a489e7-7ebc-478c-974f-94dce4bb5e03

dark mode

https://github.com/kyu08/github-issue-pr-navigator/assets/105255294/731a11f0-c165-4cbd-84c8-4e25f5db981e

